### PR TITLE
Also use gradle as build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 bin/*
 /bin/
+.gradle/
+gradle/
+build/
+.idea/
+gradlew
+gradlew.bat

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ asmcup.jar also has command line tools:
 
 If you want to improve the Sandbox or make changes to the game code itself
 you can either import the project into Eclipse or build using
-`ant build.xml` 
+`ant` or `gradle jar`
 
 ## Compete
 
@@ -114,7 +114,7 @@ Value | Command   | In | Out | Notes
 10    | sub8      | 2  | 1   | Byte Subtract
 11    | div8      | 2  | 1   | Byte Divide
 12    | mul8      | 2  | 1   | Byte Multiply
-13    | madd8     | 3  | 1   | Byte Multiply with Add 
+13    | madd8     | 3  | 1   | Byte Multiply with Add
 14    | negf      | 4  | 4   | Float Negate
 15    | addf      | 8  | 4   | Float Add
 16    | subf      | 8  | 4   | Float Subtract
@@ -376,7 +376,7 @@ There are currently no functional differences between the 4 types of obstacles. 
 Walls form rectangular rooms with one or more entrances. Gold can (currently) only be found in rooms
 
 ### Items
-	
+
 Item pickup is **WIP**.
 
 **Gold:** Points!

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,20 @@
+apply plugin: 'java'
+
+sourceSets {
+    main {
+        java {
+            srcDir 'src/'
+        }
+        resources {
+            srcDir 'src/'
+            exclude '**/*.java'
+        }
+    }
+}
+
+jar {
+  manifest {
+    attributes 'Implementation-Title': 'ASMCup Runtime',
+               'Main-Class': 'asmcup.sandbox.Main'
+  }
+}


### PR DESCRIPTION
The jar will be build with `gradle jar` and is placed inside `build/libs/`.

This makes the project possible to be opened in intellij for example. Eclipse project creation could be supported to, if you prefer.

refs #28 
