### PR TITLE
Made robot ticks respect overclock changes on same frame

### DIFF
--- a/src/asmcup/runtime/Robot.java
+++ b/src/asmcup/runtime/Robot.java
@@ -131,12 +131,12 @@ public class Robot {
 	}
 	
 	protected void tickSoftware(World world) {
-		int cycles = 1 + overclock;
+		int cyclesUsed = 0;
 		
-		while (cycles > 0) {
+		while (cyclesUsed <= overclock) {
 			vm.tick();
 			handleIO(world);
-			cycles--;
+			cyclesUsed++;
 			battery--;
 		}
 	}


### PR DESCRIPTION
Previously, IO_OVERCLOCK would only take effect after an essentially random amount of ticks. This means that robots can now e.g. force world ticks by setting overclock to 0.
