### PR TITLE
Fixed peek8/16/32 and thereby dup8 and dupf

### DIFF
--- a/src/asmcup/vm/VM.java
+++ b/src/asmcup/vm/VM.java
@@ -157,15 +157,15 @@ public class VM implements VMConsts {
 	}
 	
 	public int peek16() {
-		return peek8() | (peek8(1) << 8); 
+		return peek8(1) | (peek8(0) << 8); 
 	}
 	
 	public int peek16(int r) {
-		return peek8(r) | (peek8(r + 1) << 8);
+		return peek8(r + 1) | (peek8(r) << 8);
 	}
 	
 	public int peek32() {
-		return peek16() | (peek16(2) << 16);
+		return peek16(2) | (peek16(0) << 16);
 	}
 	
 	public float peekFloat() {

--- a/src/asmcup/vm/VM.java
+++ b/src/asmcup/vm/VM.java
@@ -153,7 +153,7 @@ public class VM implements VMConsts {
 	}
 	
 	public int peek8(int r) {
-		return ram[0xFF - ((sp + r - 1) & 0xFF)] & 0xFF;
+		return ram[0xFF - ((sp - r - 1) & 0xFF)] & 0xFF;
 	}
 	
 	public int peek16() {

--- a/src/asmcup/vm/VM.java
+++ b/src/asmcup/vm/VM.java
@@ -153,7 +153,7 @@ public class VM implements VMConsts {
 	}
 	
 	public int peek8(int r) {
-		return ram[0xFF - ((sp + r + 1) & 0xFF)] & 0xFF;
+		return ram[0xFF - ((sp + r - 1) & 0xFF)] & 0xFF;
 	}
 	
 	public int peek16() {


### PR DESCRIPTION
This bug became evident when trying to dup8/dupf something that was just pushed onto the stack.
(Add a unit test later!)
