### PR TITLE
Add ability to generate code coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,3 +32,21 @@ jar {
 dependencies {
     testCompile "junit:junit:4.12"
 }
+
+// ------------------ code coverage ------------------------------ //
+
+apply plugin: 'jacoco'
+
+jacoco {
+    toolVersion = "0.7.6.201602180812"
+    reportsDir = file("$buildDir/codecoverage")
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled false
+        csv.enabled false
+        html.destination "${buildDir}/codecoverage"
+    }
+}
+


### PR DESCRIPTION
this will be generated when running

```
gradle test && gradle jacocoTestReport
```

Note that you will need to have the task test ran before it.
