### PR TITLE
Fix typo in exception message

### DIFF
--- a/src/asmcup/compiler/Compiler.java
+++ b/src/asmcup/compiler/Compiler.java
@@ -326,7 +326,7 @@ public class Compiler implements VMConsts {
 	public static boolean isEnclosed(String s, String start, String end) {
 		if (s.startsWith(start)) {
 			if (!s.endsWith(end)) {
-				throw new IllegalArgumentException(String.format("Expected '%s'", s));
+				throw new IllegalArgumentException(String.format("Expected '%s'", end));
 			}
 			return true;
 		}


### PR DESCRIPTION
I am not entirely sure if this is the correct fix,
but it looks like this is the variable one wanted to pass
