### PR TITLE
Implemented setting beam angle (#111).

### DIFF
--- a/src/asmcup/runtime/Robot.java
+++ b/src/asmcup/runtime/Robot.java
@@ -17,6 +17,7 @@ public class Robot {
 	protected float frequency;
 	protected int gold;
 	protected float sensor;
+	protected float beamDirection;
 	protected int sensorIgnore;
 	protected int sensorFrame;
 	protected boolean ramming;
@@ -90,6 +91,10 @@ public class Robot {
 	
 	public float getSensor() {
 		return sensor;
+	}
+	
+	public float getBeamAngle() {
+		return (float)(facing + beamDirection * Math.PI / 2);
 	}
 	
 	public int getSensorFrame() {
@@ -249,8 +254,8 @@ public class Robot {
 			return;
 		}
 		
-		float cos = (float)Math.cos(facing);
-		float sin = (float)Math.sin(facing);
+		float cos = (float)Math.cos(getBeamAngle());
+		float sin = (float)Math.sin(getBeamAngle());
 		
 		for (int i=0; i < RAY_STEPS; i++) {
 			if ((i * RAY_INTERVAL) >= (lazer * LAZER_RANGE)) {
@@ -343,6 +348,9 @@ public class Robot {
 		case IO_COMPASS:
 			vm.pushFloat(facing % (float)Math.PI);
 			break;
+		case IO_BEAM_DIRECTION:
+			beamDirection = popFloatSafe(-1.0f, 1.0f);
+			break;
 		default:
 			lastInvalidIO = world.getFrame();
 			return;
@@ -352,8 +360,8 @@ public class Robot {
 	}
 	
 	protected void sensorRay(World world) {
-		float cos = (float)Math.cos(facing);
-		float sin = (float)Math.sin(facing);
+		float cos = (float)Math.cos(getBeamAngle());
+		float sin = (float)Math.sin(getBeamAngle());
 		sensorFrame = world.getFrame();
 		
 		for (int i = 0; i < RAY_STEPS; i++) {
@@ -438,6 +446,7 @@ public class Robot {
 	public static final int IO_RECEIVE = 11;
 	public static final int IO_SENSOR_CONFIG = 12;
 	public static final int IO_COMPASS = 13;
+	public static final int IO_BEAM_DIRECTION = 14;
 	
 	public static final float SPEED_MAX = 8;
 	public static final float STEER_RATE = (float)(Math.PI * 0.1);

--- a/src/asmcup/sandbox/Sandbox.java
+++ b/src/asmcup/sandbox/Sandbox.java
@@ -353,6 +353,9 @@ public class Sandbox {
 		
 		g.rotate(robot.getFacing(), sx, sy);
 		g.drawImage(bot, sx - World.TILE_HALF, sy - World.TILE_HALF, null);
+		g.setTransform(t);
+		
+		g.rotate(robot.getBeamAngle(), sx, sy);
 		
 		if (robot.getLazerEnd() > 0) {
 			int w = (int)(robot.getLazerEnd());

--- a/test/asmcup/runtime/RobotTest.java
+++ b/test/asmcup/runtime/RobotTest.java
@@ -212,6 +212,28 @@ public class RobotTest {
 		robot.handleIO(world);
 		assertEquals(42, vm.pop8());
 	}
+	
+	public void testBeamAngle() {
+		World world = generateEmptyWorld((int) robot.getX(), (int) robot.getY(), 50);
+		VM vm = robot.getVM();
+		// Face west
+		robot.setFacing(0);
+		// Beam south?
+		vm.pushFloat(1.0f);
+		vm.push8(Robot.IO_BEAM_DIRECTION);
+		vm.setIO(true);
+		robot.handleIO(world);
+		assertEquals((float)Math.PI/2, robot.getBeamAngle(), 0.0001f);
+		
+		// Face north
+		robot.setFacing(-(float)Math.PI/2);
+		// Beam north-west?
+		vm.pushFloat(-0.5f);
+		vm.push8(Robot.IO_BEAM_DIRECTION);
+		vm.setIO(true);
+		robot.handleIO(world);
+		assertEquals((float)-Math.PI * 0.75f, robot.getBeamAngle(), 0.0001f);
+	}
 
 	private World generateEmptyWorld(int x, int y, int radius) {
 		World world = new World();


### PR DESCRIPTION
Alright, here's a proposed implementation. This changes the angle of both sensor and laser.

I've used the -1.0 to 1.0 input value range to represent -PI/2 to PI/2. This makes using it in a simple bot a lot easier (no need to introduce PI in your code), bots using trigonometry might have to use a few more instructions.