### PR TITLE
Changed compass range.

### DIFF
--- a/src/asmcup/runtime/Robot.java
+++ b/src/asmcup/runtime/Robot.java
@@ -341,7 +341,7 @@ public class Robot {
 			vm.push8(world.recv(this, frequency));
 			break;
 		case IO_COMPASS:
-			vm.pushFloat(facing % (float)Math.PI);
+			vm.pushFloat(floatModPositive(facing, (float)(Math.PI * 2)));
 			break;
 		default:
 			lastInvalidIO = world.getFrame();
@@ -420,6 +420,10 @@ public class Robot {
 		}
 		
 		return f;
+	}
+	
+	protected static float floatModPositive(float dividend, float divisor) {
+		return ((dividend % divisor) + divisor) % divisor;
 	}
 	
 	public static final int IO_SENSOR = 0;


### PR DESCRIPTION
The compass now always returns a positive float between 0 and 2 pi.
Previously, e.g. facing southwest or northeast would incur the same compass value (with a range of pi).