### PR TITLE
Fixed non-deterministic test failure.

### DIFF
--- a/test/asmcup/runtime/RobotTest.java
+++ b/test/asmcup/runtime/RobotTest.java
@@ -67,7 +67,7 @@ public class RobotTest {
 
 	@Test
 	public void testMotor() {
-		World world = generateEmptyWorld((int) robot.getX(), (int) robot.getY(), 30);
+		World world = generateEmptyWorld((int) robot.getX(), (int) robot.getY(), 50);
 		float x = robot.getX();
 		float y = robot.getY();
 		robot.setMotor(1.0f);


### PR DESCRIPTION
By pure chance the motor test actually failed again. Radius 30 is not enough when tile size is 32.
I guess I missed that radius earlier?