### PR TITLE
Fixed #134

### DIFF
--- a/src/asmcup/compiler/Compiler.java
+++ b/src/asmcup/compiler/Compiler.java
@@ -359,7 +359,10 @@ public class Compiler implements VMConsts {
 				throw new IllegalArgumentException("Expected label name");
 			}
 			
-			String name = line.substring(0, pos);
+			String name = line.substring(0, pos).trim();
+			if (!isSymbol(name)) {
+				throw new IllegalArgumentException("Invalid label name: " + name);
+			}
 
 			statements.add(new Label(name));
 			line = line.substring(pos + 1).trim();

--- a/test/asmcup/compiler/CompilerTest.java
+++ b/test/asmcup/compiler/CompilerTest.java
@@ -323,12 +323,12 @@ public class CompilerTest {
         assertEquals(1, compiler.statements.size());
         assertEquals("", compiler.parseLabels("  two:more:"));
         assertEquals(3, compiler.statements.size());
+        assertEquals("", compiler.parseLabels("  with  : spaces\t: "));
+        assertEquals(5, compiler.statements.size());
         assertEquals("kein label", compiler.parseLabels("kein label"));
     }
 
-    // FIXME: Disabled for now. Implementation has an issue (#134).
-    /*
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidLabelSpaces() {
         try {
             compiler.parseLabels("label with spaces:");
@@ -338,7 +338,7 @@ public class CompilerTest {
         }
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidLabelNumbers() {
         try {
             compiler.parseLabels("123labelsMustntStartWithNumbers:");
@@ -346,7 +346,7 @@ public class CompilerTest {
         } catch (IllegalArgumentException e) {
             assert(e.getMessage().startsWith("Invalid label name"));
         }
-    }*/
+    }
 
     @Test
     public void testParseArgs() {


### PR DESCRIPTION
Additionally, fixed a bug where this code was valid but useless:
`label  : db8 #0`

The label name would be "label  " (with spaces) and thus be unusable.