### PR TITLE
Allow literal prefix (#) for floats.

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -42,7 +42,7 @@ There are four basic types of operations:
 ## Values and Addressing
 
 Literal values are denoted by a `#` in front of them. Float values can only be literals,
-so the `#` can be/must be (*not yet decided*) omitted for float literals.
+so the `#` can be omitted for float literals.
 Any values that are not literals are taken to be memory addresses.
 Values preceded by a `$` are interpreted as hexadecimal, otherwise they
 will be treated as decimals.

--- a/src/asmcup/compiler/Compiler.java
+++ b/src/asmcup/compiler/Compiler.java
@@ -192,7 +192,7 @@ public class Compiler implements VMConsts {
 			
 			public void compile() {
 				for (String s : args) {
-					writeFloat(Float.parseFloat(s));
+					writeFloat(parseFloat(s));
 				}
 			}
 		});
@@ -263,7 +263,7 @@ public class Compiler implements VMConsts {
 	}
 	
 	protected void pushLiteralFloat(String s) {
-		float f = Float.parseFloat(s);
+		float f = parseFloat(s);
 		
 		if (f == -1.0f) {
 			immediate(OP_FUNC, F_C_M1F, NO_DATA);
@@ -407,6 +407,13 @@ public class Compiler implements VMConsts {
 		catch (NumberFormatException e) {
 			throw new IllegalArgumentException("Invalid value: " + s);
 		}
+	}
+	
+	protected static float parseFloat(String s) {
+		if (isLiteral(s)) {
+			s = s.substring(1);
+		}
+		return Float.parseFloat(s);
 	}
 	
 	protected void reference(int op, int data, String s) {

--- a/test/asmcup/compiler/CompilerTest.java
+++ b/test/asmcup/compiler/CompilerTest.java
@@ -227,6 +227,18 @@ public class CompilerTest {
     public void testParseLiteralHex() {
         assertEquals(0xff, Compiler.parseLiteral("#$ff"));
     }
+    
+    @Test
+    public void testParseFloats() {
+        assertEquals(3.14159f, Compiler.parseFloat("3.14159"), 0.0001);
+        assertEquals(12000f, Compiler.parseFloat("12e3"), 0.1);
+    }
+
+    @Test
+    public void testParseLiteralFloats() {
+        assertEquals(3.14159f, Compiler.parseFloat("#3.14159"), 0.0001);
+        assertEquals(12000f, Compiler.parseFloat("#12e3"), 0.1);
+    }
 
     @Test
     public void testParseIndirection() {


### PR DESCRIPTION
No reason not to, really.