### PR TITLE
Fix bugs found by static analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: java
 jdk:
     - oraclejdk8
+
+script:
+    - gradle test
+    - gradle findbugsMain findbugsTest

--- a/build.gradle
+++ b/build.gradle
@@ -50,3 +50,17 @@ jacocoTestReport {
     }
 }
 
+// ------------------ static analysis ---------------------------- //
+
+apply plugin: 'findbugs'
+
+findbugs {
+    reportLevel = "high"
+}
+
+tasks.withType(FindBugs) {
+    reports {
+        xml.enabled false
+        html.enabled true
+    }
+}

--- a/src/asmcup/compiler/Main.java
+++ b/src/asmcup/compiler/Main.java
@@ -7,7 +7,7 @@ import java.util.List;
 public class Main {
 	public static void main(String[] args) throws IOException {
 		if (args.length < 2) {
-			System.err.printf("USAGE: asmcup-compile <in> <out>\n");
+			System.err.printf("USAGE: asmcup-compile <in> <out>%n");
 			System.exit(1);
 			return;
 		}

--- a/src/asmcup/decompiler/Decompiler.java
+++ b/src/asmcup/decompiler/Decompiler.java
@@ -34,7 +34,7 @@ public class Decompiler implements VMConsts {
 	}
 	
 	public void dump(int pc, String s) {
-		System.out.printf("%02x: %s\n", pc, s);
+		System.out.printf("%02x: %s%n", pc, s);
 	}
 
 	public int decompileCommand(byte[] ram, int pc) {

--- a/src/asmcup/decompiler/Main.java
+++ b/src/asmcup/decompiler/Main.java
@@ -6,7 +6,7 @@ import java.nio.file.Files;
 public class Main {
 	public static void main(String[] args) throws IOException {
 		if (args.length != 1) {
-			System.err.printf("USAGE: asmcup-decompiler <file>\n");
+			System.err.printf("USAGE: asmcup-decompiler <file>%n");
 			System.exit(1);
 			return;
 		}
@@ -15,7 +15,7 @@ public class Main {
 		byte[] ram = Files.readAllBytes(in.toPath());
 
 		if (ram.length != 256) {
-			System.err.printf("ERROR: Program must be 256 bytes not %d\n", ram.length);
+			System.err.printf("ERROR: Program must be 256 bytes not %d%n", ram.length);
 			System.exit(1);
 			return;
 		}

--- a/src/asmcup/genetics/Gene.java
+++ b/src/asmcup/genetics/Gene.java
@@ -1,5 +1,7 @@
 package asmcup.genetics;
 
+import java.util.Objects;
+
 public class Gene implements Comparable<Gene> {
 	public final byte[] dna;
 	public final float score;
@@ -10,7 +12,8 @@ public class Gene implements Comparable<Gene> {
 		this.gen = gen;
 		this.score = score;
 	}
-	
+
+	@Override
 	public int compareTo(Gene other) {
 		float d = score - other.score;
 		
@@ -21,5 +24,16 @@ public class Gene implements Comparable<Gene> {
 		}
 		
 		return -1;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return obj instanceof Gene && compareTo((Gene) obj) == 0;
+	}
+
+	@Override
+	public int hashCode() {
+		// explicit default implementation to hashCode the internal pointer
+		return Objects.hashCode(this);
 	}
 }

--- a/src/asmcup/runtime/Main.java
+++ b/src/asmcup/runtime/Main.java
@@ -1,6 +1,7 @@
 package asmcup.runtime;
 
 import java.io.*;
+import java.nio.charset.Charset;
 import java.util.Base64;
 
 import asmcup.vm.VM;
@@ -14,7 +15,7 @@ public class Main implements Recorder {
 		Main main = new Main();
 		
 		if (args.length > 1) {
-			System.err.printf("USAGE: asmcup-runtime [file]\n");
+			System.err.printf("USAGE: asmcup-runtime [file]%n");
 			System.exit(1);
 			return;
 		}
@@ -32,9 +33,9 @@ public class Main implements Recorder {
 	}
 	
 	public void configure(InputStream input) throws IOException {
-		InputStreamReader streamReader = new InputStreamReader(input);
+		InputStreamReader streamReader = new InputStreamReader(input, Charset.forName("US-ASCII"));
 		BufferedReader reader = new BufferedReader(streamReader);
-		String line = "";
+		String line;
 		
 		while ((line = reader.readLine()) != null) {
 			configure(line);
@@ -44,8 +45,8 @@ public class Main implements Recorder {
 	}
 	
 	public void configure(String line) {
-		String command = "";
-		String[] parts = {};
+		String command;
+		String[] parts;
 		
 		line = line.trim();
 		
@@ -118,6 +119,6 @@ public class Main implements Recorder {
 	
 	public void record(RecordedRobot robot, byte[] data) {
 		String encoded = Base64.getEncoder().encodeToString(data);
-		System.out.printf("io %d %d %s\n", world.getFrame(), robot.id, encoded);
+		System.out.printf("io %d %d %s%n", world.getFrame(), robot.id, encoded);
 	}
 }

--- a/src/asmcup/runtime/World.java
+++ b/src/asmcup/runtime/World.java
@@ -8,9 +8,11 @@ public class World {
 	protected final HashMap<Integer, byte[]> tileData;
 	protected final int seed;
 	protected int frame;
+
+	private static final Random random = new Random();
 	
 	public World() {
-		this(new Random().nextInt());
+		this(random.nextInt());
 	}
 	
 	public World(int seed) {

--- a/src/asmcup/sandbox/Sandbox.java
+++ b/src/asmcup/sandbox/Sandbox.java
@@ -224,7 +224,7 @@ public class Sandbox {
 	}
 	
 	public void resetWorld(int seed) {
-		synchronized (world) {
+		synchronized (this) {
 			world = new World(seed);
 			world.addRobot(robot);
 		}

--- a/src/asmcup/sandbox/Utils.java
+++ b/src/asmcup/sandbox/Utils.java
@@ -1,6 +1,7 @@
 package asmcup.sandbox;
 
 import java.io.*;
+import java.nio.charset.Charset;
 import java.nio.file.*;
 
 import javax.swing.*;
@@ -16,7 +17,7 @@ public class Utils {
 	}
 	
 	public static String readAsString(Path path) throws IOException {
-		return new String(Files.readAllBytes(path));
+		return new String(Files.readAllBytes(path), Charset.forName("US-ASCII"));
 	}
 	
 	public static String readAsString(JFrame frame, String ext, String desc) throws IOException {
@@ -32,11 +33,12 @@ public class Utils {
 	public static String readAsString(InputStream input) throws IOException {
 		String line;
 		StringBuilder builder = new StringBuilder();
-		InputStreamReader streamReader = new InputStreamReader(input);
+		InputStreamReader streamReader = new InputStreamReader(input, Charset.forName("US-ASCII"));
 		BufferedReader reader = new BufferedReader(streamReader);
 		
 		while ((line = reader.readLine()) != null) {
-			builder.append(line + "\n");
+			builder.append(line);
+			builder.append("\n");
 		}
 		
 		return builder.toString();

--- a/src/asmcup/vm/VM.java
+++ b/src/asmcup/vm/VM.java
@@ -4,6 +4,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Objects;
 
 public class VM implements VMConsts {
 	private final byte[] ram;
@@ -40,7 +41,12 @@ public class VM implements VMConsts {
 				getStackPointer() == vm.getStackPointer() &&
 				io == vm.io;
 	}
-	
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getMemory(), getProgramCounter(), getStackPointer(), io);
+	}
+
 	public void save(DataOutputStream stream) throws IOException {
 		stream.write(ram);
 		stream.writeByte(pc);

--- a/test/asmcup/compiler/CompilerTest.java
+++ b/test/asmcup/compiler/CompilerTest.java
@@ -174,8 +174,8 @@ public class CompilerTest {
     @Test
     public void testWriteFloat() {
         ByteBuffer bb = getByteBuffer(compiler.ram);
-        compiler.writeFloat(3.14159f);
-        assertEquals(3.14159f, bb.getFloat(0), 0.1);
+        compiler.writeFloat(1.23456f);
+        assertEquals(1.23456f, bb.getFloat(0), 0.1);
         assertEquals(0x00, bb.getInt(4)); // We're not overflowing
 
         // check pc
@@ -230,13 +230,13 @@ public class CompilerTest {
     
     @Test
     public void testParseFloats() {
-        assertEquals(3.14159f, Compiler.parseFloat("3.14159"), 0.0001);
+        assertEquals(1.23456f, Compiler.parseFloat("1.23456"), 0.0001);
         assertEquals(12000f, Compiler.parseFloat("12e3"), 0.1);
     }
 
     @Test
     public void testParseLiteralFloats() {
-        assertEquals(3.14159f, Compiler.parseFloat("#3.14159"), 0.0001);
+        assertEquals(1.23456f, Compiler.parseFloat("#1.23456"), 0.0001);
         assertEquals(12000f, Compiler.parseFloat("#12e3"), 0.1);
     }
 

--- a/test/asmcup/decompiler/DecompilerTest.java
+++ b/test/asmcup/decompiler/DecompilerTest.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 
 import asmcup.compiler.Compiler;
 
@@ -23,7 +25,11 @@ public class DecompilerTest {
 
 	@Before
 	public void setUpStreams() {
-		System.setOut(new PrintStream(out));
+		try {
+			System.setOut(new PrintStream(out, false, "UTF-8"));
+		} catch (UnsupportedEncodingException e) {
+			fail(e.getMessage());
+		}
 	}
 
 	@After
@@ -32,13 +38,13 @@ public class DecompilerTest {
 	}
 
 	@Test
-	public void testDump() {
+	public void testDump() throws UnsupportedEncodingException {
 		decompiler.dump(0xff, "blabla");
-		assertEquals("ff: blabla\n", out.toString());
+		assertEquals("ff: blabla\n", out.toString("UTF-8"));
 	}
 
 	@Test
-	public void testDecompile() {
+	public void testDecompile() throws UnsupportedEncodingException {
 		// This code is not sensible and does not produce a good or valid program
 		byte[] ram = (new Compiler()).compile(getProgram(
 				"start:",
@@ -71,7 +77,7 @@ public class DecompilerTest {
 				"10: jmp $00",
 				"12: jnz $00",
 				"14: jmp [$cc]"
-		), out.toString());
+		), out.toString("UTF-8"));
 	}
 
 	private static String getProgram(String... lines) {

--- a/test/asmcup/vm/VMTest.java
+++ b/test/asmcup/vm/VMTest.java
@@ -86,8 +86,8 @@ public class VMTest {
 	@Test
 	public void testWriteFloat() {
 		ByteBuffer bb = getByteBuffer(vm.getMemory());
-		vm.writeFloat(0, 3.14159f);
-		assertEquals(3.14159f, bb.getFloat(0), 0.1);
+		vm.writeFloat(0, 1.23456f);
+		assertEquals(1.23456f, bb.getFloat(0), 0.1);
 		assertEquals(0x00, bb.getInt(4)); // We're not overflowing
 	}
 
@@ -122,15 +122,15 @@ public class VMTest {
 
 	@Test
 	public void testReadFloat() {
-		vm.writeFloat(0, 3.14159f);
-		assertEquals(3.14159f, vm.readFloat(), 0.00001f);
+		vm.writeFloat(0, 1.23456f);
+		assertEquals(1.23456f, vm.readFloat(), 0.00001f);
 	}
 
 	@Test
 	public void testReadFloatIndirect() {
 		vm.write8(0, 42);
-		vm.writeFloat(42, 3.14159f);
-		assertEquals(3.14159f, vm.readFloatIndirect(), 0.0001f);
+		vm.writeFloat(42, 1.23456f);
+		assertEquals(1.23456f, vm.readFloatIndirect(), 0.0001f);
 	}
 
 
@@ -160,10 +160,10 @@ public class VMTest {
 
 	@Test
 	public void testPushFloat() {
-		vm.pushFloat(3.14159f);
+		vm.pushFloat(1.23456f);
 		vm.pushFloat(2.7182f);
 		assertEquals(2.7182f, vm.popFloat(), 0.0001f);
-		assertEquals(3.14159f, vm.popFloat(), 0.0001f);
+		assertEquals(1.23456f, vm.popFloat(), 0.0001f);
 	}
 
 	@Test


### PR DESCRIPTION
this include:
- Comparing float against equality
- bad locking variables
- relying on default charsets
- compareTo, equal, hashCode discrepancies
- using platform specific newline in printf

I also included travis to run these and reports errors.
Of course this will only be practical if there are no false positives.
Let's see how good this works.