### PR TITLE
Fixed some internal errors in the spawn window.

### DIFF
--- a/src/asmcup/evaluation/SpawnEvaluator.java
+++ b/src/asmcup/evaluation/SpawnEvaluator.java
@@ -16,7 +16,7 @@ public class SpawnEvaluator extends Evaluator {
 		float score = super.score(ram) * scoringCount;
 		
 		Scorer scorer = new Scorer();
-		for (Spawn spawn : spawns) {
+		for (Spawn spawn : spawns.getIterable()) {
 			score += scorer.calculate360(ram, spawn);
 		}
 		

--- a/src/asmcup/evaluation/Spawns.java
+++ b/src/asmcup/evaluation/Spawns.java
@@ -1,23 +1,26 @@
 package asmcup.evaluation;
 
-import java.util.ArrayList;
+import java.util.*;
+
 import javax.swing.ListModel;
-import javax.swing.event.ListDataEvent;
-import javax.swing.event.ListDataListener;
+import javax.swing.event.*;
 
 import asmcup.genetics.Spawn;
-import asmcup.runtime.Robot;
-import asmcup.runtime.World;
-import asmcup.sandbox.Mouse;
-import asmcup.sandbox.Sandbox;
+import asmcup.runtime.*;
+import asmcup.sandbox.*;
 
-public class Spawns extends ArrayList<Spawn> implements ListModel<Spawn> {
+public class Spawns implements ListModel<Spawn> {
+	private ArrayList<Spawn> spawns = new ArrayList<>();
 	protected final Sandbox sandbox;
 	
 	ArrayList<ListDataListener> listeners = new ArrayList<>();
 	
 	public Spawns(Sandbox sandbox) {
 		this.sandbox = sandbox;
+	}
+	
+	public AbstractCollection<Spawn> getIterable() {
+		return new ArrayList<Spawn>(spawns);
 	}
 	
 	public void addSpawnAtMouse() {
@@ -34,44 +37,51 @@ public class Spawns extends ArrayList<Spawn> implements ListModel<Spawn> {
 		add(spawn);
 	}
 
-	@Override
 	public boolean add(Spawn spawn) {
-		super.add(spawn);
-		notifyListeners(size()-1, size()-1);
+		spawns.add(spawn);
+		notifyListeners(spawns.size()-1, spawns.size()-1);
 		return true;
 	}
 	
-	@Override
 	public Spawn remove(int index) {
-		Spawn ret = super.remove(index);
-		notifyListeners(index, index);
+		if (index < 0 || index >= spawns.size()) {
+			return null;
+		}
+		Spawn ret = spawns.remove(index);
+		notifyListeners(index, size());
 		return ret;
 	}
 	
-	@Override
 	public void clear() {
-		int previousSize = size();
-		super.clear();
+		int previousSize = spawns.size();
+		spawns.clear();
 		notifyListeners(0, previousSize-1);
 	}
 	
 	public int getCombinedSeed() {
 		int seed = 0;
 		
-		for (Spawn spawn : this) {
+		for (Spawn spawn : spawns) {
 			seed += spawn.seed;
 		}
 		return seed;
 	}
 
+	public int size() {
+		return spawns.size();
+	}
+
 	public int getSize() {
-		return size();
+		return spawns.size();
 	}
 	
 	public Spawn getElementAt(int index) {
-		return get(index);
+		if (index < 0 || index >= size()) {
+			return null;
+		}
+		return spawns.get(index);
 	}
-	
+
 	private void notifyListeners(int index0, int index1) {
 		for (ListDataListener l : listeners) {
 			// Yeah, lazy, I know.

--- a/src/asmcup/evaluation/SpawnsWindow.java
+++ b/src/asmcup/evaluation/SpawnsWindow.java
@@ -14,7 +14,6 @@ public class SpawnsWindow extends JFrame {
 	protected final Spawns spawns;
 	protected final FrontPanel panel = new FrontPanel();
 	protected JList<Spawn> spawnList;
-	protected ListModel<Spawn> listModel;
 
 	protected JButton addButton = new JButton("Add current");
 	protected JButton deleteButton = new JButton("Delete");
@@ -54,16 +53,24 @@ public class SpawnsWindow extends JFrame {
 	}
 	
 	public void deleteOne() {
+		selectLastIfNone();
 		int index = spawnList.getSelectedIndex();
-		if (index != -1) {
-			spawns.remove(index);
-		}
+		// Error handling happens in there. Can't trust JList apparently.
+		spawns.remove(index);
+		selectLastIfNone();
 	}
 	
 	public void applyOne() {
-		int index = spawnList.getSelectedIndex();
-		if (index != -1) {
-			sandbox.loadSpawn(spawns.get(index));
+		selectLastIfNone();
+		Spawn spawn = spawnList.getSelectedValue();
+		if (spawn != null) {
+			sandbox.loadSpawn(spawn);
+		}
+	}
+	
+	public void selectLastIfNone() {
+		if (spawnList.getSelectedValue() == null) {
+			spawnList.setSelectedIndex(spawns.size() - 1);
 		}
 	}
 	

--- a/src/asmcup/sandbox/Sandbox.java
+++ b/src/asmcup/sandbox/Sandbox.java
@@ -277,7 +277,7 @@ public class Sandbox {
 		
 		g.setColor(Color.PINK);
 		
-		for (Spawn spawn : spawns) {
+		for (Spawn spawn : spawns.getIterable()) {
 			int x = screenX(spawn.x);
 			int y = screenY(spawn.y);
 			


### PR DESCRIPTION
`Spawns` no longer is that weird amalgamation of an `ArrayList` and a `ListModel`.
This change also makes the iteration over spawns thread-safe (as in, you can only iterate over a copy, preventing comodification).
I had to introduce some manual bounds checking because JList _really_ doesn't want to be consistent with the `ListModel` behind it.