### PR TITLE
Fixed world size.

### DIFF
--- a/src/asmcup/runtime/World.java
+++ b/src/asmcup/runtime/World.java
@@ -210,6 +210,6 @@ public class World {
 	public static final int TILES_PER_CELL = 20;
 	public static final int CELL_SIZE = TILES_PER_CELL * TILE_SIZE;
 	public static final int CELL_COUNT = 0xFF;
-	public static final int SIZE = TILE_SIZE * TILES_PER_CELL * CELL_COUNT;
+	public static final int SIZE = TILE_SIZE * TILES_PER_CELL * (CELL_COUNT + 1);
 	public static final int CENTER = SIZE / 2;
 }


### PR DESCRIPTION
All instances where World.SIZE is used were actually looking for this value, not the old one.

For example, the Load World dialog wouldn't let you input coordinates beyond 32 \* 20 \* 255 (top left corner of bottom-right-most cell, not bottom right), and bots would be prevented from actually entering the bottom-most and right-most cells.

I should note that the actual problem may be that 256 cells are generated in each direction when CELL_COUNT is 255. But meh. ¯\\\_(ツ)\_/¯