### PR TITLE
Fixed compiler reporting wrong lines.

### DIFF
--- a/src/asmcup/sandbox/CodeEditor.java
+++ b/src/asmcup/sandbox/CodeEditor.java
@@ -109,8 +109,7 @@ public class CodeEditor extends JFrame {
 			statusLabel.setText(String.format("Bytes used: %d", compiler.getBytesUsed()));
 		} catch (Exception e) {
 			e.printStackTrace();
-			JOptionPane.showMessageDialog(this,
-					String.format("%s on line %d", e.getMessage(), compiler.getCurrentLine()));
+			JOptionPane.showMessageDialog(this, e.getMessage());
 			return false;
 		}
 		

--- a/test/asmcup/compiler/CompilerTest.java
+++ b/test/asmcup/compiler/CompilerTest.java
@@ -24,7 +24,7 @@ public class CompilerTest {
             compiler.compile("push8 notfoundlabel");
             fail("Compiler did not fail on undefined label.");
         } catch (IllegalArgumentException e) {
-            assertEquals("Cannot find label 'notfoundlabel'", e.getMessage());
+            assert(e.getMessage().startsWith("Cannot find label 'notfoundlabel'"));
         }
     }
 
@@ -34,7 +34,7 @@ public class CompilerTest {
             compiler.compile("undefinedfunction #0");
             fail("Compiler did not fail on undefined function.");
         } catch (IllegalArgumentException e) {
-            assertEquals("Unknown function undefinedfunction", e.getMessage());
+            assert(e.getMessage().startsWith("Unknown function undefinedfunction"));
         }
     }
 
@@ -44,7 +44,7 @@ public class CompilerTest {
             compiler.compile("label:\nlabel:");
             fail("Compiler did not fail on redefined label.");
         } catch (IllegalArgumentException e) {
-            assertEquals("Redefined label 'label'", e.getMessage());
+            assert(e.getMessage().startsWith("Redefined label 'label'"));
         }
     }
 


### PR DESCRIPTION
When errors would happen during statement measuring/compilation, the
error message would just list the last line in the input code as the
source of the problem. Now it gets the line correct every time.