### PR TITLE
Floats must now be literals (#).

### DIFF
--- a/test/asmcup/compiler/CompilerTest.java
+++ b/test/asmcup/compiler/CompilerTest.java
@@ -234,15 +234,9 @@ public class CompilerTest {
     }
     
     @Test
-    public void testParseFloats() {
-        assertEquals(1.23456f, Compiler.parseFloat("1.23456"), 0.0001);
-        assertEquals(12000f, Compiler.parseFloat("12e3"), 0.1);
-    }
-
-    @Test
     public void testParseLiteralFloats() {
-        assertEquals(1.23456f, Compiler.parseFloat("#1.23456"), 0.0001);
-        assertEquals(12000f, Compiler.parseFloat("#12e3"), 0.1);
+        assertEquals(1.23456f, Compiler.parseLiteralFloat("#1.23456"), 0.0001);
+        assertEquals(12000f, Compiler.parseLiteralFloat("#12e3"), 0.1);
     }
 
     @Test
@@ -254,11 +248,11 @@ public class CompilerTest {
     @Test
     public void testPushes() {
     	compiler.compile("push8 #13 \n push8 37 \n push8 #$ab \n push8 $cd \n" + 
-				"pushf 1.2");
+				"pushf #1.2 \n pushf 12 \n pushf $34");
     }
     
     public void testPushesRelative() {
-    	compiler.compile("label: dbf 0.0 \n push8r label");
+    	compiler.compile("label: dbf #0.0 \n push8r label");
     	compiler.compile("push8r 5 \n push8r $0a");
     }
     
@@ -269,7 +263,7 @@ public class CompilerTest {
     
     @Test
     public void testPopsRelative() {
-    	compiler.compile("label: dbf 0.0 \n pop8r label");
+    	compiler.compile("label: dbf #0.0 \n pop8r label");
     	compiler.compile("pop8r 7 \n pop8r $0a");
     }
 
@@ -295,6 +289,36 @@ public class CompilerTest {
             fail("Compiler did not fail on referencing a literal.");
         } catch (IllegalArgumentException e) {
             assert(e.getMessage().startsWith("Cannot address a literal"));
+        }
+    }
+    
+    @Test 
+    public void testNonLiteralFloatDbf() {
+        try {
+        	compiler.compile("dbf 13.1");
+            fail("Compiler did not fail on non-literal float.");
+        } catch (IllegalArgumentException e) {
+            assert(e.getMessage().startsWith("Float literals must"));
+        }
+    }
+    
+    @Test 
+    public void testNonLiteralFloatPushf() {
+        try {
+        	compiler.compile("pushf 13.1");
+            fail("Compiler did not fail on non-literal float.");
+        } catch (IllegalArgumentException e) {
+            assert(e.getMessage().startsWith("Invalid value"));
+        }
+    }
+    
+    @Test 
+    public void testIllegalFloatPush8() {
+        try {
+        	compiler.compile("push8 13.1");
+            fail("Compiler did not fail on push8 with a float.");
+        } catch (IllegalArgumentException e) {
+            assert(e.getMessage().startsWith("Invalid value"));
         }
     }
     

--- a/test/asmcup/decompiler/DecompilerTest.java
+++ b/test/asmcup/decompiler/DecompilerTest.java
@@ -36,19 +36,17 @@ public class DecompilerTest {
 				"start:",
 				"push8 #0",
 				"push8 #42",
-				"pushf 42.0",
+				"pushf #42.0",
 				"pushf start",
 				"popf $fa",
 				"pop8 $fb",
 				"push8 $fc",
 				"jmp start",
 				"jnz start",
-				"jmp ($cc)"
-				// https://github.com/asmcup/runtime/issues/99
-				// "popf ($a)",
-				// "pop8 [$b]",
-				// https://github.com/asmcup/runtime/issues/186
-				// "pushf $ab"
+				"jmp ($cc)",
+				"popf ($a)",
+				"pop8 [$b]",
+				"pushf $ab"
 		));
 
 		decompiler.decompile(ram);
@@ -64,7 +62,10 @@ public class DecompilerTest {
 				"L0e: push8 $fc",
 				"L10: jmp $00",
 				"L12: jnz $00",
-				"L14: jmp [$cc]"
+				"L14: jmp [$cc]",
+				"L16: popf [$0a]",
+				"L18: pop8 [$0b]",
+				"L1a: pushf $ab"
 		), out.toString("UTF-8"));
 	}
 


### PR DESCRIPTION
I tried hard to warn users wherever they might have to change existing
programs. There are some places (like pop8 #0.0) where it jumps the gun a
bit, but better than the reverse imo.

Fixes #186.