### PR TITLE
Decompiler fuzzing

### DIFF
--- a/src/asmcup/compiler/Compiler.java
+++ b/src/asmcup/compiler/Compiler.java
@@ -546,13 +546,20 @@ public class Compiler implements VMConsts {
 			
 			public void compileImpl() {
 				int addr = getAddress(s);
+				// Allowed range: -32 to 31
 				int r = addr - (pc + 1);
-				
-				if (r < -32 || r > 31) {
-					throw new IllegalArgumentException("Address is not within range");
+				r = (r + 32) & 0xFF;
+				// Allowed range now: 0 to 63
+				if ((r >> 6) != 0 || 
+					(r == 31) || // (and not one of the magics)
+					(r == 32) ||
+					(r == 33) ||
+					(r == 0))    // This would technically work for jnzr
+				{
+					throw new IllegalArgumentException("Unacceptable target address distance");
 				}
 				
-				writeOp(op, 32 + r);
+				writeOp(op, r);
 			}
 		});
 	}

--- a/src/asmcup/compiler/Compiler.java
+++ b/src/asmcup/compiler/Compiler.java
@@ -548,18 +548,18 @@ public class Compiler implements VMConsts {
 				int addr = getAddress(s);
 				// Allowed range: -32 to 31
 				int r = addr - (pc + 1);
-				r = (r + 32) & 0xFF;
+				int data = (r + 32) & 0xFF;
 				// Allowed range now: 0 to 63
-				if ((r >> 6) != 0 || 
-					(r == 31) || // (and not one of the magics)
-					(r == 32) ||
-					(r == 33) ||
-					(r == 0))    // This would technically work for jnzr
+				if ((data >> 6) != 0 || 
+					(data == 31) || // (and not one of the magics)
+					(data == 32) ||
+					(data == 33) ||
+					((data == 0) && (op != OP_BRANCH)))
 				{
 					throw new IllegalArgumentException("Unacceptable target address distance");
 				}
 				
-				writeOp(op, r);
+				writeOp(op, data);
 			}
 		});
 	}

--- a/src/asmcup/decompiler/Decompiler.java
+++ b/src/asmcup/decompiler/Decompiler.java
@@ -98,7 +98,7 @@ public class Decompiler implements VMConsts {
 		
 		int r = data - 32;
 		addr = (pc + r) & 0xFF;
-		dump(pc, String.format("pop8 $%02x ; relative %d", addr, r));
+		dump(pc, String.format("pop8r $%02x ; relative %d", addr, r));
 		return 1;
 	}
 	
@@ -122,7 +122,7 @@ public class Decompiler implements VMConsts {
 		
 		int r = data - 32;
 		addr = (pc + r) & 0xFF;
-		dump(pc, String.format("jnz $%02x  ; relative %d", addr, r));
+		dump(pc, String.format("jnzr $%02x  ; relative %d", addr, r));
 		return 1;
 	}
 
@@ -132,17 +132,13 @@ public class Decompiler implements VMConsts {
 
 		switch (data) {
 		case MAGIC_PUSH_BYTE_IMMEDIATE:
-			addr = read8(ram, pc + 1);
-			dump(pc, String.format("push8 #$%02x", addr));
-			return 2;
+			return verbosePushByte(ram, pc);
 		case MAGIC_PUSH_BYTE_MEMORY:
 			addr = read8(ram, pc + 1);
 			dump(pc, String.format("push8 $%02x", addr));
 			return 2;
 		case MAGIC_PUSH_FLOAT_IMMEDIATE:
-			f = readFloat(ram, pc + 1);
-			dump(pc, String.format("pushf #%f", f));
-			return 5;
+			return verbosePushFloat(ram, pc);
 		case MAGIC_PUSH_FLOAT_MEMORY:
 			addr = read8(ram, pc + 1);
 			dump(pc, String.format("pushf $%02x", addr));
@@ -151,7 +147,48 @@ public class Decompiler implements VMConsts {
 
 		int r = data - 32;
 		addr = (pc + r) & 0xFF;
-		dump(pc, String.format("push8 $%02x  ; relative %d", addr, r));
+		dump(pc, String.format("push8r $%02x  ; relative %d", addr, r));
 		return 1;
+	}
+	
+	protected int verbosePushByte(byte[] ram, int pc) {
+		// We just read a 2 byte push8 that would get condensed into the 1 byte
+		// function call by the compiler. This may break programs when they are
+		// decompiled and then recompiled because addresses may change.
+		int value = read8(ram, pc + 1);
+		
+		switch (value) {
+		case 0:
+		case 1:
+		case 2:
+		case 3:
+		case 4:
+		case 255:
+			int instruction = (MAGIC_PUSH_BYTE_IMMEDIATE << 2) + OP_PUSH;
+			dump(pc,   String.format("db8 #$%02x  ; verbose push8 #value", instruction));
+			dump(pc+1, String.format("db8 #$%02x  ; (continued)", value));
+			break;
+		default:
+			dump(pc, String.format("push8 #$%02x", value));
+		}
+		return 2;
+	}
+	
+	protected int verbosePushFloat(byte[] ram, int pc) {
+		// We just read a 5 byte pushf that would get condensed into the 1 byte
+		// function call by the compiler. This may break programs when they are
+		// decompiled and then recompiled because addresses may change.
+		float value = readFloat(ram, pc + 1);
+		
+		if (value == -1.0f || value == 0.0f ||
+			value == 1.0f  || value == 2.0f ||
+			value == 3.0f  || Float.isInfinite(value)) {
+			int instruction = (MAGIC_PUSH_FLOAT_IMMEDIATE << 2) + OP_PUSH;
+			dump(pc,   String.format("db8 #$%02x  ; verbose pushf #value", instruction));
+			dump(pc+1, String.format("dbf #%f  ; (continued)", value));
+		} else {
+			dump(pc, String.format("pushf #%f", value));
+		}
+		return 5;
 	}
 }

--- a/src/asmcup/decompiler/Decompiler.java
+++ b/src/asmcup/decompiler/Decompiler.java
@@ -152,7 +152,7 @@ public class Decompiler implements VMConsts {
 	}
 	
 	protected int verbosePushByte(byte[] ram, int pc) {
-		// We just read a 2 byte push8 that would get condensed into the 1 byte
+		// We just read a 2 byte push8 that could get condensed into the 1 byte
 		// function call by the compiler. This may break programs when they are
 		// decompiled and then recompiled because addresses may change.
 		int value = read8(ram, pc + 1);
@@ -175,7 +175,7 @@ public class Decompiler implements VMConsts {
 	}
 	
 	protected int verbosePushFloat(byte[] ram, int pc) {
-		// We just read a 5 byte pushf that would get condensed into the 1 byte
+		// We just read a 5 byte pushf that could get condensed into the 1 byte
 		// function call by the compiler. This may break programs when they are
 		// decompiled and then recompiled because addresses may change.
 		float value = readFloat(ram, pc + 1);

--- a/src/asmcup/decompiler/Decompiler.java
+++ b/src/asmcup/decompiler/Decompiler.java
@@ -31,7 +31,7 @@ public class Decompiler implements VMConsts {
 	}
 
 	public int read8(byte[] ram, int pc) {
-		return ram[pc] & 0xFF;
+		return ram[pc & 0xFF] & 0xFF;
 	}
 
 	public int read16(byte[] ram, int pc) {
@@ -97,7 +97,7 @@ public class Decompiler implements VMConsts {
 		}
 		
 		int r = data - 32;
-		addr = pc + r;
+		addr = (pc + r) & 0xFF;
 		dump(pc, String.format("pop8 $%02x ; relative %d", addr, r));
 		return 1;
 	}
@@ -141,7 +141,7 @@ public class Decompiler implements VMConsts {
 			return 2;
 		case MAGIC_PUSH_FLOAT_IMMEDIATE:
 			f = readFloat(ram, pc + 1);
-			dump(pc, String.format("pushf %f", f));
+			dump(pc, String.format("pushf #%f", f));
 			return 5;
 		case MAGIC_PUSH_FLOAT_MEMORY:
 			addr = read8(ram, pc + 1);

--- a/src/asmcup/decompiler/Decompiler.java
+++ b/src/asmcup/decompiler/Decompiler.java
@@ -97,7 +97,7 @@ public class Decompiler implements VMConsts {
 		}
 		
 		int r = data - 32;
-		addr = (pc + r) & 0xFF;
+		addr = (pc + r + 1) & 0xFF;
 		dump(pc, String.format("pop8r $%02x ; relative %d", addr, r));
 		return 1;
 	}
@@ -121,7 +121,7 @@ public class Decompiler implements VMConsts {
 		}
 		
 		int r = data - 32;
-		addr = (pc + r) & 0xFF;
+		addr = (pc + r + 1) & 0xFF;
 		dump(pc, String.format("jnzr $%02x  ; relative %d", addr, r));
 		return 1;
 	}
@@ -146,7 +146,7 @@ public class Decompiler implements VMConsts {
 		}
 
 		int r = data - 32;
-		addr = (pc + r) & 0xFF;
+		addr = (pc + r + 1) & 0xFF;
 		dump(pc, String.format("push8r $%02x  ; relative %d", addr, r));
 		return 1;
 	}
@@ -185,9 +185,9 @@ public class Decompiler implements VMConsts {
 			value == 3.0f  || Float.isInfinite(value)) {
 			int instruction = (MAGIC_PUSH_FLOAT_IMMEDIATE << 2) + OP_PUSH;
 			dump(pc,   String.format("db8 #$%02x  ; verbose pushf #value", instruction));
-			dump(pc+1, String.format("dbf #%f  ; (continued)", value));
+			dump(pc+1, String.format("dbf #%.9e  ; (continued)", value));
 		} else {
-			dump(pc, String.format("pushf #%f", value));
+			dump(pc, String.format("pushf #%.9e", value));
 		}
 		return 5;
 	}

--- a/src/asmcup/vm/VMFuncs.java
+++ b/src/asmcup/vm/VMFuncs.java
@@ -83,5 +83,8 @@ public interface VMFuncs {
 	public static final int F_FT8 = 59;
 	public static final int F_FTF = 60;
 	
+	public static final int F_NOP61 = 61;
+	public static final int F_NOP62 = 62;
+	
 	public static final int F_IO = 63;
 }

--- a/test/asmcup/compiler/CompilerTest.java
+++ b/test/asmcup/compiler/CompilerTest.java
@@ -253,7 +253,7 @@ public class CompilerTest {
     
     public void testPushesRelative() {
     	compiler.compile("label: dbf #0.0 \n push8r label");
-    	compiler.compile("push8r 5 \n push8r $0a");
+    	compiler.compile("push8r 5 \n push8r $fa");
     }
     
     @Test
@@ -264,12 +264,24 @@ public class CompilerTest {
     @Test
     public void testPopsRelative() {
     	compiler.compile("label: dbf #0.0 \n pop8r label");
-    	compiler.compile("pop8r 7 \n pop8r $0a");
+    	compiler.compile("pop8r 7 \n pop8r $fa");
     }
 
     @Test
     public void testPopsIndirect() {
     	compiler.compile("pop8 [13] \n pop8 [$cd] \n popf [13] \n popf [$cd]");
+    }
+    
+    @Test
+    public void testJumps() {
+    	compiler.compile("jmp 37 \n jnz 13 \n jmp [11]");
+    	compiler.compile("jmp $37 \n jnz $13 \n jmp [$11]");
+    }
+    
+    @Test
+    public void testJumpsRelative() {
+    	compiler.compile("label: dbf #0.0 \n jnzr label");
+    	compiler.compile("jnzr 07 \n jnzr $fa");
     }
 
     @Test
@@ -315,7 +327,7 @@ public class CompilerTest {
     @Test 
     public void testIllegalFloatPush8() {
         try {
-        	compiler.compile("push8 13.1");
+        	compiler.compile("push8 #13.1");
             fail("Compiler did not fail on push8 with a float.");
         } catch (IllegalArgumentException e) {
             assert(e.getMessage().startsWith("Invalid value"));

--- a/test/asmcup/decompiler/DecompilerTest.java
+++ b/test/asmcup/decompiler/DecompilerTest.java
@@ -68,6 +68,45 @@ public class DecompilerTest {
 				"L1a: pushf $ab"
 		), out.toString("UTF-8"));
 	}
+	
+	@Test 
+	public void testIdentityByteConstants() throws UnsupportedEncodingException {
+		byte[] ram = (new Compiler()).compile(getProgram(
+				"push8 #-1",
+				"push8 #0",
+				"push8 #1",
+				"push8 #2",
+				"push8 #3",
+				"push8 #4",
+				"push8 #5",
+				"push8 #6",
+				"push8 #255",
+				"push8 #256",
+				"push8 #257",
+				"push8 #-1000",
+				"push8 #1001"
+		));
+		
+		checkDecompileCompileIdentity(ram);
+	}
+	
+	@Test 
+	public void testIdentityFloatConstants() throws UnsupportedEncodingException {
+		byte[] ram = (new Compiler()).compile(getProgram(
+				"pushf #1.0",
+				"pushf #-0.0",
+				"pushf #42",
+				"pushf #NaN",
+				"pushf #0.1",
+				"pushf #7.0",
+				"pushf #7.0e20",
+				"pushf #13.37e-20",
+				"pushf #Infinity",
+				"pushf #-Infinity"
+		));
+		
+		checkDecompileCompileIdentity(ram);
+	}
 
 	@Test
 	public void testFuzzedPattern0() throws UnsupportedEncodingException {
@@ -111,7 +150,7 @@ public class DecompilerTest {
 		byte[] newRam = compiler.compile(out.toString("UTF-8"));
 		
 		for (int i = 0; i < 256; i++) {
-			assertEquals(ram[i], newRam[i]);
+			assertEquals(String.format("Memory differs at %02x", i), ram[i], newRam[i]);
 		}
 	}
 

--- a/test/asmcup/decompiler/DecompilerTest.java
+++ b/test/asmcup/decompiler/DecompilerTest.java
@@ -108,9 +108,10 @@ public class DecompilerTest {
 		
 		decompiler.decompile(ram);
 		System.out.println(out.toString("UTF-8"));
-		byte[] newRam = compiler.compile(out.toString());
+		byte[] newRam = compiler.compile(out.toString("UTF-8"));
 		
 		for (int i = 0; i < 256; i++) {
+			System.out.println(String.format("%d: %d | %d", i, ram[i], newRam[i]));
 			assertEquals(ram[i], newRam[i]);
 		}
 	}

--- a/test/asmcup/decompiler/DecompilerTest.java
+++ b/test/asmcup/decompiler/DecompilerTest.java
@@ -55,7 +55,7 @@ public class DecompilerTest {
 				// "start:" label produces no output!
 				"L00: c_0",
 				"L01: push8 #$2a",
-				"L03: pushf #42.000000",
+				"L03: pushf #4.200000000e+01",
 				"L08: pushf $00",
 				"L0a: popf $fa",
 				"L0c: pop8 $fb",
@@ -105,13 +105,12 @@ public class DecompilerTest {
 	private void checkDecompileCompileIdentity(byte[] ram)
 			throws UnsupportedEncodingException {
 		Compiler compiler = new Compiler();
+		out.reset();
 		
 		decompiler.decompile(ram);
-		System.out.println(out.toString("UTF-8"));
 		byte[] newRam = compiler.compile(out.toString("UTF-8"));
 		
 		for (int i = 0; i < 256; i++) {
-			System.out.println(String.format("%d: %d | %d", i, ram[i], newRam[i]));
 			assertEquals(ram[i], newRam[i]);
 		}
 	}

--- a/test/asmcup/decompiler/DecompilerTest.java
+++ b/test/asmcup/decompiler/DecompilerTest.java
@@ -55,7 +55,7 @@ public class DecompilerTest {
 				// "start:" label produces no output!
 				"L00: c_0",
 				"L01: push8 #$2a",
-				"L03: pushf 42.000000",
+				"L03: pushf #42.000000",
 				"L08: pushf $00",
 				"L0a: popf $fa",
 				"L0c: pop8 $fb",
@@ -70,9 +70,17 @@ public class DecompilerTest {
 	}
 
 	@Test
-	public void testFuzzedPatterns() throws UnsupportedEncodingException {
+	public void testFuzzedPattern0() throws UnsupportedEncodingException {
 		testFuzzedWithPadding(0);
+	}
+
+	@Test
+	public void testFuzzedPattern1() throws UnsupportedEncodingException {
 		testFuzzedWithPadding(1);
+	}
+
+	@Test
+	public void testFuzzedPattern4() throws UnsupportedEncodingException {
 		testFuzzedWithPadding(4);
 	}
 	
@@ -99,16 +107,11 @@ public class DecompilerTest {
 		Compiler compiler = new Compiler();
 		
 		decompiler.decompile(ram);
-		ram = compiler.compile(out.toString("UTF-8"));
-		// It is possible that the compiler collapsed e.g. a verbose (2-byte)
-		// push8 #0
-		// into the constant function form, so we run another cycle.
-		out.reset();
-		decompiler.decompile(ram);
+		System.out.println(out.toString("UTF-8"));
 		byte[] newRam = compiler.compile(out.toString());
 		
 		for (int i = 0; i < 256; i++) {
-			assert(ram[i] == newRam[i]);
+			assertEquals(ram[i], newRam[i]);
 		}
 	}
 


### PR DESCRIPTION
Checking that no code changes when decompiling and then re-compiling a ROM should both help identify issues in either of them and also ensure that they can be used without worries.

I have created a row of tests for this and already eliminated some decompiler bugs. Just opening this PR now so others don't have to redo the work (sorry @SiebelsTim!) and because there's something to discuss. See below.